### PR TITLE
Add context on CarrierService API Requirements (FI)

### DIFF
--- a/resources/lang/fi/app.php
+++ b/resources/lang/fi/app.php
@@ -101,7 +101,7 @@ return [
         'country' => 'Maa',
         'email' => 'Sähköposti',
         'phone' => 'Puhelinnumero',
-        'enable_carrier_api' => 'Noutopistetoiminto tarvitsee Carrier Services APIn toimintaan. Carrier Service API on saatavilla vain Shopify tai Shopify Plus tilauksiin. Pyydä Shopifyn asiakaspalvelu kytkemään päälle Carrier Service API.',
+        'enable_carrier_api' => ‘Noutopistetoiminto tarvitsee <a style="font-weight:bold" href="https://shopify.dev/docs/api/admin-rest/2023-01/resources/carrierservice" target="_blank">CarrierService API</a>:n toimintaan. CarrierService API on automaattisesti käytössä Advanced Shopify- ja Shopify Plus -sopimuksilla. <a style="font-weight:bold" href="https://help.shopify.com/fi/messages" target="_blank">Ottamalla yhteyttä Shopifyn tukeen</a>, CarrierService API on mahdollista aktivoida myös Shopify-sopimuksella. Tämä maksaa kuukausittaisella Shopify-sopimuksella 17 euroa kuukaudessa, mutta se sisältyy <b>Shopify-vuosisopimuksen</b> hintaan. Voit vaihtaa sopimusta menemällä kohtaan <b>Admin > Asetukset > Sopimus</b>. CarrierService API ei ole saatavilla Basic Shopify- tai Shopify Starter -sopimuksilla. Löydät lisätietoa <a href="https://help.shopify.com/fi/manual/shipping/setting-up-and-managing-your-shipping/enabling-shipping-carriers" target="_blank">klikkaamalla tästä</a>.’,
         'pickuppoint_providers' => 'Minkä toimittajan noutopisteet haetaan?',
         'pickuppoints_count' => 'Kuinka monta lähintä noutopistettä näytetään ostajalle?',
         'pickuppoints_count_0' => 'Älä näytä noutopisteitä',


### PR DESCRIPTION
Merchants using Pakettikauppa contact Shopify Support regularly without full context of what's required of them to get the API enabled. This update helps to increase adoption speed by mitigating back-and-forths for context gathering.

Referring to: https://github.com/Pakettikauppa/shopify-embedded-app/pull/365/commits/a87fc42c90ea39ae98f4f36e2dd155deff617e35

If there's a particular reason why the text has to be shortened, consider the following:

‘Noutopistetoiminto tarvitsee <a style="font-weight:bold" href="https://shopify.dev/docs/api/admin-rest/2023-01/resources/carrierservice" target="_blank">CarrierService API</a>:n toimintaan. Vaihda <b>Shopify-sopimukseen</b> ja <a style="font-weight:bold" href="https://help.shopify.com/fi/messages" target="_blank">pyydä Shopify-tukea kytkemään sen päälle</a>.'